### PR TITLE
Support erts versions prior to R14

### DIFF
--- a/src/kvc.erl
+++ b/src/kvc.erl
@@ -20,11 +20,11 @@
 %% @spec path(kvc_key() | [kvc_key()], kvc_obj()) -> term() | []
 %% @doc Return the result of the query Path on P.
 path(Path, P) when is_binary(Path) ->
-    path(binary:split(Path, <<".">>, [global]), P);
+    path(binary_to_list(Path), P);
 path(Path, P) when is_atom(Path) ->
     path(atom_to_binary(Path, utf8), P);
 path(Path=[N | _], P) when is_integer(N) ->
-    path(iolist_to_binary(Path), P);
+    path(string:tokens(Path, "."), P);
 path([], P) ->
     P;
 path([K | Rest], P) ->


### PR DESCRIPTION
This patch adds support for R13 (which is still in widespread use) by
switching from `binary:split` to `string:tokens`, in order to decompose
the _path_ being searched.
