### PR TITLE
Optional delimiter

### DIFF
--- a/test/kvc_tests.erl
+++ b/test/kvc_tests.erl
@@ -94,6 +94,12 @@ value_edge_test() ->
        kvc:value([256], [{foo, ok}], [])),
     ok.
 
+alternative_delimiter_test() ->
+    ?assertEqual(
+        scm,
+        kvc:path("repositories/github.com/api",
+                [{repositories,[{"github.com", [{api,scm}]}]}], <<"/">>)).
+
 path_plist_test() ->
     lists:foreach(
       fun (F) ->


### PR DESCRIPTION
This patch adds support for using alternative delimiters in the _path_, which is pretty useful if you're navigating elements that contain a dot character which would normally fail.
